### PR TITLE
Add constructors to entities and remove setTimestamp() in Communication

### DIFF
--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/Communication.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/Communication.java
@@ -34,6 +34,23 @@ public class Communication {
     // Relation with CommunicationTemplate.
 
     /**
+     * Communication's default no-arg constructor
+     */
+    public Communication() {}
+
+    /**
+     *
+     * @param timestamp the timestamp of when the communication-instance was created
+     * @param medium the medium of the communication, such as SMS or email
+     * @param content the text content of the communication-instance
+     */
+    public Communication(Timestamp timestamp, String medium, String content) {
+        this.timestamp = timestamp;
+        this.medium = medium;
+        this.content = content;
+    }
+
+    /**
      *
      * @return the timestamp of the communication
      */

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/CommunicationTemplate.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/CommunicationTemplate.java
@@ -18,6 +18,21 @@ public class CommunicationTemplate {
     private String template;
 
     /**
+     * CommunicationTemplate's default no-arg constructor
+     */
+    public CommunicationTemplate() {}
+
+    /**
+     *
+     * @param name the name of the template
+     * @param template the content of the template
+     */
+    public CommunicationTemplate(String name, String template) {
+        this.name = name;
+        this.template = template;
+    }
+
+    /**
      *
      * @return the name of the ConfirmationType
      */

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/Edition.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/Edition.java
@@ -22,6 +22,23 @@ public class Edition {
     private boolean active;
 
     /**
+     * Edition's default no-arg constructor
+     */
+    public Edition() {}
+
+    /**
+     *
+     * @param name the name of the OSOC-edition
+     * @param year the year in which the edition takes place
+     * @param active whether or not the edition is still active
+     */
+    public Edition(String name, int year, boolean active) {
+        this.name = name;
+        this.year = year;
+        this.active = active;
+    }
+
+    /**
      *
      * @return whether or not the edition is active
      */

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/Invitation.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/Invitation.java
@@ -26,6 +26,21 @@ public class Invitation {
     private boolean used;
 
     /**
+     * Invitation's default no-arg constructor
+     */
+    public Invitation() {}
+
+    /**
+     *
+     * @param timestamp the timestamp on which the invitation was created
+     * @param used whether or not the invitation has been used
+     */
+    public Invitation(Timestamp timestamp, boolean used) {
+        this.timestamp = timestamp;
+        this.used = used;
+    }
+
+    /**
      *
      * @return The timestamp of the invitation
      */
@@ -39,14 +54,6 @@ public class Invitation {
      */
     public boolean isUsed() {
         return used;
-    }
-
-    /**
-     *
-     * @param newTimestamp timestamp of the creation of the invitation
-     */
-    public void setTimestamp(final Timestamp newTimestamp) {
-        timestamp = newTimestamp;
     }
 
     /**

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/Organisation.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/Organisation.java
@@ -26,6 +26,21 @@ public class Organisation {
     private String name;
 
     /**
+     * Organisation's default no-arg constructor
+     */
+    public Organisation() {}
+
+    /**
+     *
+     * @param info a string containing some info about the organisation
+     * @param name the name of the organisation
+     */
+    public Organisation(String info, String name) {
+        this.info = info;
+        this.name = name;
+    }
+
+    /**
      *
      * @return The info of the organisation
      */

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/Project.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/Project.java
@@ -29,6 +29,21 @@ public class Project {
     private String name;
 
     /**
+     * Project's default no-arg constructor
+     */
+    public Project() {}
+
+    /**
+     *
+     * @param goals a list containing the goals of the project
+     * @param name the name of the project
+     */
+    public Project(List<String> goals, String name) {
+        this.goals = goals;
+        this.name = name;
+    }
+
+    /**
      *
      * @return The goals of the project
      */

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/Skill.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/Skill.java
@@ -26,6 +26,21 @@ public class Skill {
     private String additionalInfo;
 
     /**
+     * Skill's default no-arg constructor
+     */
+    public Skill() {}
+
+    /**
+     *
+     * @param name the name of the skill
+     * @param additionalInfo a string containing additional info about the project
+     */
+    public Skill(String name, String additionalInfo) {
+        this.name = name;
+        this.additionalInfo = additionalInfo;
+    }
+
+    /**
      *
      * @return The description of the skill
      */

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/SkillTypeEntity.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/SkillTypeEntity.java
@@ -17,6 +17,21 @@ public class SkillTypeEntity {
     private String colour;
 
     /**
+     * SkillTypeEntity's default no-arg constructor
+     */
+    public SkillTypeEntity() {}
+
+    /**
+     *
+     * @param skillType the type of the skill
+     * @param colour the colour associated with this SkillType
+     */
+    public SkillTypeEntity(SkillType skillType, String colour) {
+        this.skillType = skillType;
+        this.colour = colour;
+    }
+
+    /**
      *
      * @return the colour associated with this SkillType
      */

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/User.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/User.java
@@ -33,9 +33,28 @@ public class User {
     private String lastName;
 
     /**
-     * Role/ power this user has.
+     * Role/power this user has.
      */
     private UserRole userRole;
+
+    /**
+     * User's default no-arg constructor
+     */
+    public User() {}
+
+    /**
+     *
+     * @param email the email of the user
+     * @param firstName the first name of the user
+     * @param lastName the last name of the user
+     * @param userRole the role of the user
+     */
+    public User(String email, String firstName, String lastName, UserRole userRole) {
+        this.email = email;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.userRole = userRole;
+    }
 
     /**
      *

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/student/Student.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/student/Student.java
@@ -140,6 +140,68 @@ public class Student {
     private String additionalStudentInfo;
 
     /**
+     * Student's default no-arg constructor
+     */
+    public Student() {}
+
+    /**
+     *
+     * @param email the email of the student
+     * @param firstName the first name of the student
+     * @param lastName the last name of the student
+     * @param gender the gender of the student
+     * @param pronounsType the pronounsType of the student
+     * @param callName the callname of the student
+     * @param pronouns the pronouns of the student
+     * @param mostFluentLanguage the language in which the student is moest fluent
+     * @param englishProficiency the student's proficiency in English
+     * @param phoneNumber the phone number of the student
+     * @param curriculumVitaeURI the URI of the student's curriculum vitae
+     * @param portfolioURI the URI of the student's portfolio
+     * @param motivationURI the URI of the student's motivation
+     * @param writtenMotivation the written motivation of the student
+     * @param educationLevel the education level of the student
+     * @param currentDiploma the current diploma of the student
+     * @param durationCurrentDegree the duration of the student's current degree
+     * @param yearInCourse the current year (first, second,...) of the student's course
+     * @param institutionName the name of the institution of the student's course
+     * @param bestSkill the best skill of the student
+     * @param osocExperience the level of OSOC-experience of the student
+     * @param additionalStudentInfo additional info about the student
+     */
+    public Student(String email, String firstName, String lastName,
+                   Gender gender, PronounsType pronounsType, String callName,
+                   List<String> pronouns, String mostFluentLanguage,
+                   EnglishProficiency englishProficiency, String phoneNumber,
+                   URI curriculumVitaeURI, URI portfolioURI, URI motivationURI,
+                   String writtenMotivation, String educationLevel, String currentDiploma,
+                   int durationCurrentDegree, String yearInCourse, String institutionName,
+                   String bestSkill, OsocExperience osocExperience, String additionalStudentInfo) {
+        this.email = email;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.gender = gender;
+        this.pronounsType = pronounsType;
+        this.callName = callName;
+        this.pronouns = pronouns;
+        this.mostFluentLanguage = mostFluentLanguage;
+        this.englishProficiency = englishProficiency;
+        this.phoneNumber = phoneNumber;
+        this.curriculumVitaeURI = curriculumVitaeURI;
+        this.portfolioURI = portfolioURI;
+        this.motivationURI = motivationURI;
+        this.writtenMotivation = writtenMotivation;
+        this.educationLevel = educationLevel;
+        this.currentDiploma = currentDiploma;
+        this.durationCurrentDegree = durationCurrentDegree;
+        this.yearInCourse = yearInCourse;
+        this.institutionName = institutionName;
+        this.bestSkill = bestSkill;
+        this.osocExperience = osocExperience;
+        this.additionalStudentInfo = additionalStudentInfo;
+    }
+
+    /**
      *
      * @return the email of the student
      */

--- a/backend/src/main/java/com/osoc6/OSOC6/database/models/student/Study.java
+++ b/backend/src/main/java/com/osoc6/OSOC6/database/models/student/Study.java
@@ -25,6 +25,21 @@ public class Study {
     private StudyCourse studyCourse;
 
     /**
+     * Study's default no-arg constructor
+     */
+    public Study() {}
+
+    /**
+     *
+     * @param course the title of the study
+     * @param studyCourse the course studied by the student
+     */
+    public Study(String course, StudyCourse studyCourse) {
+        this.course = course;
+        this.studyCourse = studyCourse;
+    }
+
+    /**
      *
      * @return the title of the study.
      */


### PR DESCRIPTION
This branch adds no-args constructors to all entities, as well as a constructor with all fields except Id. The setTimestamp-method in Communication is also removed.